### PR TITLE
Update SoapArgumentConverter.php

### DIFF
--- a/src/Andreani/Resources/SoapArgumentConverter.php
+++ b/src/Andreani/Resources/SoapArgumentConverter.php
@@ -317,7 +317,7 @@ class SoapArgumentConverter implements ArgumentConverter{
                 'tarifa' => intval($consulta->getTarifa()),
                 'valorDeclaradoConIva' => doubleval($consulta->getValorDeclaradoConIVA()),
                 'volumenDelEnvioEnCm3' => intval($consulta->getVolumenDelEnvioEnCm3()),
-                'sucursalDeImposicion' => intval($consulta->getSucursalImposicion())
+                'sucursalDeImposicion' => $consulta->getSucursalImposicion()
             )
         );
         if ($consulta->getCategoriaPeso() != null) {


### PR DESCRIPTION
Se debe quitar intval al campo sucursalDeImposicion en el request de GenerarEnvioConDatosDeImpresionYRemitente, pues dicho campo debe poder enviarse en null, y dicho intval genera que el request se haga con valor cero (0) en vez de null